### PR TITLE
(Unfinished pull request) Customizable Expedition Background

### DIFF
--- a/src/ExpeditionHooks.cs
+++ b/src/ExpeditionHooks.cs
@@ -217,7 +217,7 @@ namespace SlugBase
             new (nameof(MSCSceneID.Landscape_CL)),
         };
 
-        // Assigning the name, description, and a random background scene
+        // Assigning the name, description, and background scene
         private static void CharacterSelectPage_UpdateSelectedSlugcat(On.Menu.CharacterSelectPage.orig_UpdateSelectedSlugcat orig, CharacterSelectPage self, int num)
         {
             if (num < 0 || num >= ExpeditionGame.playableCharacters.Count) num = 1; // This might not be necessary, but better be safe
@@ -227,6 +227,7 @@ namespace SlugBase
             {
                 SlugcatStats.Name name = ExpeditionGame.playableCharacters[num];
                 string rodentName = "If you're seeing this in game then I think i might have screwed up<LINE>-Nacu";
+                self.slugcatScene = randomScenes[UnityEngine.Random.Range(0, randomScenes.Length - (ModManager.MSC ? 0 : 7))]; // sets it to be random
                 if (SlugBaseCharacter.TryGet(name, out var chara))
                 {
                     rodentName = chara.DisplayName;
@@ -258,7 +259,6 @@ namespace SlugBase
                 }
 
                 self.slugcatName.text = self.menu.Translate(rodentName).ToUpper();
-                self.slugcatScene = randomScenes[UnityEngine.Random.Range(0, randomScenes.Length - (ModManager.MSC ? 0 : 7))];
             }
         }
 

--- a/src/ExpeditionHooks.cs
+++ b/src/ExpeditionHooks.cs
@@ -227,7 +227,7 @@ namespace SlugBase
             {
                 SlugcatStats.Name name = ExpeditionGame.playableCharacters[num];
                 string rodentName = "If you're seeing this in game then I think i might have screwed up<LINE>-Nacu";
-                self.slugcatScene = randomScenes[UnityEngine.Random.Range(0, randomScenes.Length - (ModManager.MSC ? 0 : 7))]; // sets it to be random
+                self.slugcatScene = randomScenes[UnityEngine.Random.Range(0, randomScenes.Length - (ModManager.MSC ? 0 : 7))]; // Sets background to be random
                 if (SlugBaseCharacter.TryGet(name, out var chara))
                 {
                     rodentName = chara.DisplayName;
@@ -237,6 +237,14 @@ namespace SlugBase
                     }
 
                     self.slugcatDescription.text = self.menu.Translate(description).Replace("<LINE>", Environment.NewLine);
+
+                    sceneNum = -1; // AHHHH HOW DO I MAKE IT REFERENCE THE BACKGROUND THINGY
+                    
+                    if (sceneNum > -1) // If the sceneNum is -1 (the default), it keeps the background randomized.
+                    {
+                        if (sceneNum < 23 || ModManager.MSC) { // If the sceneNum has a MSC background selected and MSC isn't enabled, it is also randomized.
+                        self.slugcatScene = randomScenes[sceneNum];
+                    }
                 }
 
                 if (name == SlugcatStats.Name.Night)

--- a/src/SlugBaseCharacter.cs
+++ b/src/SlugBaseCharacter.cs
@@ -52,7 +52,8 @@ namespace SlugBase
             {
                 { "id", id },
                 { "name", "No Name" },
-                { "description", "No description." }
+                { "description", "No description." },
+                { "background", -1 }
             };
 
             return Registry.Add(JsonConverter.ToJson(data)).Value;
@@ -80,6 +81,11 @@ namespace SlugBase
         public string DisplayName { get; set; }
 
         /// <summary>
+        /// The ID of this character's background in the Expedition select screen. Is an integer between -1 and 29, where -1 chooses a random one.
+        /// </summary>
+        public int Background { get; set; }
+
+        /// <summary>
         /// A description of this character that appears on the select menu.
         /// </summary>
         public string Description { get; set; }
@@ -95,6 +101,11 @@ namespace SlugBase
 
             DisplayName = json.GetString("name");
             Description = json.GetString("description");
+            if (json.TryGet("background")) {
+                Background = json.Get("background");
+            } else {
+                Background = -1;
+            }
 
             Features.Clear();
             if (json.TryGet("features")?.AsObject() is JsonObject obj)


### PR DESCRIPTION
Now, I'll be real, I got no idea how to fully implement this by myself. I tried, but even if I somehow got everything right with no errors, it's still not completely done. (Check ExpeditionHooks for details.)

Anyway, the reason I made this is as a sort of suggestion to this mod so that users can customize which background is used in the Expedition menu, rather than ALWAYS making it randomized. (I did implement the logic so that it doesn't choose an MSC scene if MSC isn't enabled, and also still keeps the randomization function if the user doesn't choose a background.)